### PR TITLE
Migrate the 2014 site to Jekyll as a template for 2016

### DIFF
--- a/src/site/.gitignore
+++ b/src/site/.gitignore
@@ -1,0 +1,3 @@
+_site
+.sass-cache
+.jekyll-metadata

--- a/src/site/2016/index.html
+++ b/src/site/2016/index.html
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+
+{% include promo.html %}
+{% include countdown.html %}
+{% include talks.html %}
+{% include schedule.html %}
+{% include speakers.html %}
+{% include sponsors.html %}
+{% include other.html %}

--- a/src/site/_config.yml
+++ b/src/site/_config.yml
@@ -1,0 +1,12 @@
+# Site settings
+title: PNWScala 2016
+email: info@pnwscala.org
+description: PNWScala 2016 - The Pacific Northwest's Scala Conference that you don't want to miss!
+baseurl: ""
+assets_basedir: "/2014"
+url: "http://pnwscala.org"
+twitter_username: PNWScala
+github_username:  PNWScala
+
+# Build settings
+markdown: kramdown

--- a/src/site/_data/2016/event.yml
+++ b/src/site/_data/2016/event.yml
@@ -1,0 +1,7 @@
+event_year: 2016
+event_month_day: JUL 1-2
+event_month_day_long: July 1st and 2nd
+event_start: "2016/07/01 08:30:00"
+event_price: 100
+cfp_submit_deadline: May 20th
+cfp_selection_deadline: May 28th

--- a/src/site/_data/2016/schedule.yml
+++ b/src/site/_data/2016/schedule.yml
@@ -1,0 +1,59 @@
+- date: July 1
+  day: Friday
+  events:
+    - time: 8:30 am
+      title: Doors Open / Badge Pickup
+    - time: 8:50 am
+      title: Welcome / Announcements
+    - time: 9:00 am
+      speaker: Jon Pretty
+    - time: 9:50 am
+      speaker: Brendan McAdams
+    - time: 10:40 am
+      speaker: Stephen Compall
+    - time: 11:30 am
+      title: Lunch
+    - time: 12:30 pm
+      speaker: Marc Millstone
+    - time: 2:00 pm
+      title: Break
+    - time: 2:20 pm
+      speaker: Evan Chan
+    - time: 3:10 pm
+      speaker: Helena Edelson
+    - time: 4:00 pm
+      title: Break
+    - time: 4:20 pm
+      speaker: Vlad Ureche
+    - time: 5:10 pm
+      speaker: Leif Wickland
+
+- date: July 2
+  day: Saturday
+  events:
+    - time: 8:30 am
+      title: Doors Open
+    - time: 8:50 am
+      title: Announcements
+    - time: 9:00 am
+      speaker: Avi Bryant
+    - time: 9:50 am
+      speaker: Marconi Lanna
+    - time: 10:40 am
+      speaker: Ryan Tanner
+    - time: 11:30 am
+      title: Lunch
+    - time: 12:30 pm
+      speaker: Li Haoyi
+    - time: 2:00 pm
+      title: Break
+    - time: 2:20 pm
+      speaker: Erik Osheim
+    - time: 3:10 pm
+      speaker: Gabriel Claramunt
+    - time: 4:00 pm
+      title: Break
+    - time: 4:20 pm
+      speaker: Jean-Rémi Desjardins, Eddie Carlson
+    - time: 5:10 pm
+      speaker: Mark Schaake

--- a/src/site/_data/2016/speakers.yml
+++ b/src/site/_data/2016/speakers.yml
@@ -1,0 +1,34 @@
+- name: Avi Bryant
+  bio: Avi has led product, engineering, and data science teams at Etsy, Twitter and Dabble DB (which he co-founded and Twitter acquired). He’s known for his open source work on projects such as Seaside, Scalding, and Algebird. Avi currently works at Stripe.
+- name: Eddie Carlson
+  bio: Eddie has been building distributed search services in Scala for the last year and a half. He joined Whitepages two years ago, after graduating from the University of Washington. Whitepages had just begun to adopt Scala, and Eddie has worked to pioneer Scala usage at the company. He attended last year’s PNW Scala Conference.
+- name: Gabriel Claramunt
+  bio: Gabriel was a happy enterprise developer until he found Scala and ruined his life. Now he wanders around mumbling strange words like "functors" and "curry-howard". In spite of claiming to live in Uruguay, he had a pretty nomadic life, having lived in many places across the Americas.
+- name: Evan Chan
+  bio: Evan loves to design, build, and improve bleeding edge distributed data and backend systems using the latest in open source technologies. He has led the design and implementation of multiple big data platforms based on Storm, Spark, Kafka, Cassandra, and Scala/Akka, including a columnar real-time distributed query engine. He is an active contributor to the Apache Spark project and co-creator of the open-source Spark Job Server. He is a big believer in GitHub, open source, and meetups, and have given talks at various conferences including the Spark Summit and Cassandra Summit. He has Bachelor's and Master's degrees in Electrical Engineering from Stanford University.
+- name: Stephen Compall
+  bio: Stephen Compall, is one of the Scalaz devs, firmly in the typelevel camp, currently working with the Ermine group at McGraw Hill Financial. You can find a few of his writings about Scala on the typelevel blog.
+- name: Jean-Rémi Desjardins
+  bio: Jean-Rémi Desjardins just started at Whitepages a few months ago. He joins bringing a wealth of experience in Scala. Although he has only been involved in the Scala community for just over two years now, he has made contributions to important open source projects such as sbt, Play, shapeless, scalaz and Scala itself.
+- name: Helena Edelson
+  bio: Helena has been working with Scala since 2010 in R&D as a Senior Cloud Engineer at VMware and CrowdStrike, and has recently joined the DataStax (Cassandra) Analytics Engineering Team. She is an open source committer on Akka, Spark Cassandra Connector, Scala Cassandra Driver, (soon to be) Slick (adding Cassandra), & previous Spring Committer.
+- name: Li Haoyi
+  bio: Li Haoyi is a software engineer at Dropbox who writes Python/Coffeescript during the day and Scala/Scala.js at night.
+- name: Marconi Lanna
+  bio: Marconi has been writing software for fun and profit since last century, when the Internet was still black & white and silent. He loves computers, Internet, curly braces, angle brackets, Scala, and working with great people. Marconi is Senior Software Innovator at Originate and spends most of his free time trying to get his little daughter out of trouble. He has been programming in Scala since 2010.
+- name: Brendan McAdams
+  bio: Having recently returned from several wilderness years of being an itinerant conference speaker, trainer, & consultant for such fine companies as MongoDB & Typesafe, Brendan now writes Scala code for Netflix, building beautiful APIs with Scalatra & Swagger.
+- name: Marc Millstone
+  bio: Marc Millstone is a Lead Backend Engineer at Socrata, leading the Analytics and Machine Learning (AniML) team. Before joining Socrata, Marc spent two years in the Mathematical Sciences group at IBM Watson Research, as both a post-doc and Research Staff Member. He obtained his Ph.D. from the Courant Institute of Mathematical Sciences at New York University, where he worked jointly with Lawrence Berkeley National lab, specializing in methods for solving large-scale practical optimization problems.
+- name: Erik Osheim
+  bio: Erik is one of the creators of Spire, a Typelevel project designed to support fast, generic, and precise numerical programming in Scala. He is a contributor to the Scala compiler and standard library, and uses Scala to push the limits of JVM performance and expressiveness. Erik works at Meetup, where he collects, processes, and analyzes data to learn how to more effectively create community.
+- name: Jon Pretty
+  bio: Jon has been involved in the Scala community for the last ten years, having launched the first commercial and open-source Scala software back in 2005. Since then, he has successfully deployed Scala projects into small, medium and large businesses, and UK government, but is best known these days for his work on Rapture.
+- name: Mark Schaake
+  bio: Mark Schaake is a full-stack software engineer at the Allen Institute for Artificial Intelligence. He's been a software engineer since 2005. He's been full-time developing with Scala and Akka since 2011. He is passionate about Scala and Akka (and all things reactive). He enjoys building web services with Spray and web applications with AngularJS.
+- name: Ryan Tanner
+  bio: Ryan Tanner lives in Boulder, CO and is a full-stack developer at Conspire, working primarily with Scala, Akka, Play, ElasticSearch and Neo4j. Conspire tells you exactly how to get the best introduction to whoever you want to meet — a customer, employer or investor.
+- name: Vlad Ureche
+  bio: Vlad is a PhD student in the Scala Lab at EPFL, where he's working on optimizing high-level patterns in the Scala programming language down to fast JVM bytecode. His main project, miniboxing (scala-miniboxing.org), is aimed at compiling generic classes down to very efficient bytecode. Vlad also contributed to the Scala compiler in the areas of specialization, the JVM backend and on the scaladoc tool, where you may have seen the diagrams and the implicit member listings he developed.
+- name: Leif Wickland
+  bio: Leif Wickland writes Scala at Oracle in a quiet little corner that nobody has heard about. He lives in Bozeman, Montana, where he attempts to keep up with the neighbors by running, cycling, and skiing long distances on various surfaces. He's better at riding a bike uphill than downhill. He's getting better at skiing uphill. He still sucks at running at any pitch.

--- a/src/site/_data/2016/sponsors.yml
+++ b/src/site/_data/2016/sponsors.yml
@@ -1,0 +1,37 @@
+- tier: 1
+  title: Platinum
+  companies:
+    - name: Socrata
+      url: "http://www.socrata.com"
+      logo_url: "../assets/img/socrata_logo_150px_wide.png"
+- tier: 2
+  title: Gold
+  companies:
+    - name: janrain
+      url: "http://janrain.com"
+      logo_url: "../assets/img/janrain_logo_header.png"
+- tier: 3
+  title: Silver
+  companies:
+    - name: Whitepages
+      url: "http://www.whitepages.com"
+      logo_url: "/assets/img/whitepages_new.png"
+      logo_styling: "-webkit-filter: invert(0.6);"
+    - name: 47 Degrees
+      url: "http://www.47deg.com/"
+      logo_url: "../assets/img/47-logo.png"
+      logo_styling: "width:60px;"
+    - name: BOLDRADIUS
+      url: "http://boldradius.com"
+      logo_url: "/assets/img/BoldRadius-logo.png"
+      logo_styling: "padding-bottom: 4px;"
+- tier: 4
+  title: Friend of PNWScala
+  companies:
+    - name: Typesafe
+      url: "http://www.typesafe.com"
+      logo_url: "../assets/img/typesafe.png"
+    - name: Geezeo
+      url: "http://www.geezeo.com/"
+      logo_url: "/assets/img/geezeo_logo.png"
+      logo_styling: "padding-bottom: 10px;"

--- a/src/site/_data/2016/talks.yml
+++ b/src/site/_data/2016/talks.yml
@@ -1,0 +1,155 @@
+- title: "Rapture: The Art of the One-Liner"
+  speaker: "Jon Pretty"
+  slides_url: "http://rapture.io/talks/one-liners/portland.html"
+  video_url: "https://www.youtube.com/embed/SKdKovRlrgs"
+  description: "Rapture is a collection of libraries for everyday programming tasks like I/O, JSON & XML processing and cryptography, with a focus on beautiful, concise and intuitive code. Rapture packs a lot of power into a single line of code, and Jon will race through fifty of Rapture's smartest one-liners faster than one-a-minute, showing you how easy it is to perform everyday file and network I/O, structured data and cryptography operations, without compromising type safety. All the code in the talk will be easy for beginners to understand, but more advanced developers may also learn some new tricks, so there should be something for everyone!"
+
+- title: "The First Hit is Always Free: A Skeptic's Look at scalaz' Gateway Drugs"
+  speaker: "Brendan McAdams"
+  slides_url: "https://speakerdeck.com/bwmcadams/pnwscala-2014-a-skeptics-look-at-scalazs-gateway-drugs"
+  video_url: "https://www.youtube.com/embed/GGPE-Hh0L1I"
+  description: >
+    We've all seen them on the corner of our local software development neighborhoods: FP purists, shamelessly peddling scalaz to unsuspecting developers. Lured in by promises of Free Monoids, Semigroups, and Endofunctors these developers soon seem lost in throes of ecstatic coding.<br/><br/>
+    To the skeptical and stubbornly practical among us, the above might ring a little true – especially if read in Rob Serling's voice. Images of gibbering horrors lurking in the depths of mathematical perfection swim before our eyes.<br/><br/>
+    But what if there is true value in the world of scalaz? What if it is possible to use these tools for good (and a little bit of evil – it's fun to use learning for evil!) and profit... Without getting hopelessly lost in the opium dens of FP?<br/><br/>
+    In this talk we will look at some of the "gateway drugs" of scalaz: Validation, NonEmptyList, \/, OptionT, and more. How do they work from a practical standpoint? What is their value for real world applications? And just how fun is it to *really* code with these tools?
+
+- title: "Types out of patmat"
+  speaker: "Stephen Compall"
+  slides_url: "http://nocandysw.com/types-out-of-patmat.pdf"
+  video_url: "https://www.youtube.com/embed/p1mYHDSNSQo"
+  description: "At first glance, the pattern matcher appears to be a mechanism merely for choosing among structural conditions of your data structures. However, scalac is much more powerful than that; many patterns have interesting type-level consequences on the other side of their associated rocketships (=>). This is a powerful tool for modeling in a functional style, as well as a source of interesting type-system bugs. We'll examine various type-level effects of patterns, how you can use them to write safer programs, and what pitfalls arise in scalac's current implementation."
+
+- title: "Don't cross the streams"
+  speaker: "Marc Millstone"
+  slides_url: "https://github.com/splittingfield/tallyho"
+  video_url: "https://www.youtube.com/embed/NYy1t_0hJ6U"
+  description: >
+    Streaming algorithms are a set of techniques for computing on data streams in which the stream of data is presented as a sequence of elements with each element only being processed once. Additionally, these methods are only allowed a constant memory footprint, independent of the size of the input stream. These constraints often lead to required tradeoffs. Solutions are often correct to a threshold, with approximations being required. Understanding the vast application of these methods and how to best integrate them into their software should be a core competency in the modern engineers toolbox.<br/><br/>
+    This talk will weave together<br/>
+    <ol>
+    <li>real-world applications of streaming algorithms encountered here at Socrata,</li>
+    <li>the types and data structures (with open-source implementations in Scala) used internally to implement our streaming algorithm data pipeline,</li>
+    <li>the theory and data structures behind approximation algorithms including the popular Count-Min Sketch and HyperLogLog as well as other lesser-known techniques, and</li>
+    <li>references to and examples of integrating JVM-based implementations of these methods found in Twitter’s Algebird and Clearspring’s stream-lib into the working engineer’s data pipeline.</li>
+    </ol>
+
+- title: "Apache Spark I: From Scala Collections to Fast Interactive Big Data with Spark"
+  speaker: "Evan Chan"
+  slides_url: "http://velvia.github.io/presentations/scala-collections-spark-intro-2014/index.html#/"
+  video_url: "https://www.youtube.com/embed/3RnBuyea5Cs"
+  description: "This session introduces you to Spark by starting with something basic: Scala collections and functional data transforms. We then look at how Spark expands the functional collection concept to enable massively distributed, fast computations. The second half of the talk is for those of you who want to know the secrets to make Spark really fly for querying tabular datasets. We will dive into row vs columnar datastores and the facilities that Spark has for enabling interactive data analysis, including Spark SQL and the in-memory columnar cache. Learn why Scala's functional collections are the best foundation for working with data!"
+
+- title: "Apache Spark II: Streaming Big Data Analytics with Team Apache, Scala & Akka"
+  speaker: "Helena Edelson"
+  slides_url: "http://www.slideshare.net/helenaedelson/streaming-big-data-with-apache-spark-apache-kafka-and-apache-cassandra-delivering-meaning-in-nearreal-time-at-high-velocity-at-massive-scale"
+  video_url: "https://www.youtube.com/embed/J8FPrcsfqeY"
+  description: "In this talk we will step into Spark over Cassandra with Spark Streaming and Kafka. Then put it in the context of an event-driven Akka application for real-time delivery of meaning at high velocity. We will do this by showing how to easily integrate Apache Spark and Spark Streaming with Apache Cassandra and Apache Kafka using the Spark Cassandra Connector. All within a common use case: working with time-series data, which Cassandra excells at for data locality and speed."
+
+- title: "Miniboxing: JVM Generics without the overhead"
+  speaker: "Vlad Ureche"
+  slides_url: "https://speakerdeck.com/vladureche/miniboxing-jvm-generics-without-the-overhead"
+  video_url: "https://www.youtube.com/embed/RnIupOJv_oM"
+  description: >
+    Generics are now a must-have in any statically typed programming language. Yet, there is a strong tension between the uniform interface exposed to programmers and the low level implementation, which has to deal with data of different sizes and semantics: booleans, integers, floating-point numbers and heap objects. Different languages have taken in very different paths to implementing generics, each with its own advantages and drawbacks. In Java and other JVM languages the standard is boxing primitive values, meaning that heap objects are used to carry primitive values. This leads to significant slowdowns and increased heap consumption, especially when using generic collections for primitive types.<br/><br/>
+    Scala proposes specialization as an alternative to boxing: the compiler can duplicate and adapt user code for each primitive type, thus using unboxed data. Specialization has been shown to reliably speed up code and is extensively used in established community libraries, such as spire (non/spire) and breeze (scalanlp.org). But statically duplicating code can result in significant jar sizes and long compilation times. For example, specializing a 3-element tuple, which takes three type parameters, yields 1000 almost-identical classes.<br/><br/>
+    In the miniboxing project we set out to reduce the static bytecode size while maintaining optimality: we build on the idea of tagged union, thus offering a single variant of the code for all primitive value types. This means the 3-element tuple can now be specialized with just 8 classes. But matching the performance of specialization was a long and convoluted journey. In this presentation I will explain the basics of miniboxing and show what we had to do to match the speed of specialized code.<br/><br/>
+    The project's website, scala-miniboxing.org, contains all you need to get started: the miniboxing compiler plugin, documentation, usage examples and benchmarks.
+
+- title: "Towards a Safer Scala"
+  speaker: "Leif Wickland"
+  slides_url: "https://docs.google.com/presentation/d/1vI_x3oqZTPqrtcRaSNOleXs0xB_PwL7XaG11Us5O2CM/edit?usp=sharing"
+  video_url: "https://www.youtube.com/embed/HEeB_eH326c"
+  description: >
+    Scala has many, well-known WTF LOLs that result from the language too enthusiastically attempting to help the programmer. Scala can also be written across a wide range of styles from the Typelevel to the Better Java.<br/><br/>
+    The Scala ecosystem has static analysis and linting tools which can help avoid confusing behavior, baffling compiler messages, and divergent coding styles. We'll survey the available tools, considering which can be best applied in greenfield and existing projects.<br/><br/>
+    Attendees will leave with steps to immediately improve their production builds and strategies to introduce more sweeping changes with time.
+
+- title: "Adding Tree and Tree: Distributed Decision Tree Learning"
+  speaker: "Avi Bryant"
+  slides_url: "http://www.slideshare.net/AviBryant/adding-tree-and-tree"
+  video_url: "https://www.youtube.com/embed/zMY44CLIBcU"
+  description: "Brushfire is a framework for distributed, supervised learning of ensembles of decision trees. It is designed to be extremely scalable (both in number of observations and number of features) and extremely customizable: it makes heavy use of Scala generics and typeclasses to allow easy parameterization of each stage of the tree building algorithm. This talk will walk through the overall architecture and algorithm, then show some simple concrete examples of using Brushfire with Scalding to build trees on Hadoop."
+
+- title: "What's new since Programming in Scala"
+  speaker: "Marconi Lanna"
+  slides_url: "https://github.com/marconilanna/PNWScala2014"
+  video_url: "https://www.youtube.com/embed/Mg56PCiPguw"
+  description: >
+    <i>Programming in Scala</i>, by Martin Odersky et al., is one of the most comprehensive and the de facto reference for Scala.<br/><br/>
+    However, the book, originally published in 2008 for Scala 2.7.2, has not been updated since its second edition in 2010, covering up until Scala 2.8.1. In the meantime, Scala had 3 major releases with numerous fresh and advanced features.<br/><br/>
+    While we wait for a third edition of Programming in Scala to describe all the latest and greatest Scala features introduced in the last 4 years, this talk presents the main features introduced in Scala 2.9, 2.10, and 2.11:<br/>
+    <ul>
+    <li>Parallel collections</li>
+    <li>Value classes, implicit classes, and extension methods</li>
+    <li>String interpolation</li>
+    <li>Futures and Promises</li>
+    <li>Akka actors</li>
+    <li>Macros and quasiquotes</li>
+    <li>Reflection</li>
+    <li>Modularization</li>
+    <li>Dynamic types</li>
+    <li>Error handling with Try</li>
+    <li>The App trait</li>
+    <li>New methods in collections</li>
+    <li>Case classes with more than 22 parameters</li>
+    <li>Predef.???</li>
+    <li>sbt incremental compilation</li>
+    <li>2.12 and beyond: what's in Scala future?</li>
+    </ul>
+
+- title: "One Year of Akka"
+  speaker: "Ryan Tanner"
+  slides_url: "https://www.dropbox.com/s/xxdhyyvxrh6d9sf/PNWScala.pdf?dl=0"
+  video_url: "https://www.youtube.com/embed/VrZAlTa03cg"
+  description: >
+    How do three people build a scalable backend in a language only one has ever used before in just three months? By getting something else to do the heavy lifting.<br/><br/>
+    When Conspire graduated from TechStars and began planning our revamped product, we knew we needed a backend that was resilient, scalable and simple to understand. I was the company’s first hire and the only person on the team with any Scala experience but I convinced them to go with Akka and Scala. In roughly four months, we built exactly the backend we envisioned.<br/><br/>
+    That system has been in production for over a year. I'll discuss the challenges we faced with Scala and Akka and the lessons we've learned as we adapt our system to the changing needs of the business. Most importantly, I'll talk about what we did wrong and how we're addressing those issues going forward. (Bonus: the story of how our cluster crashed and burned the first time we put it into production!)
+
+- title: "Hands-on Scala.js"
+  speaker: "Li Haoyi"
+  slides_url: "https://dl.dropboxusercontent.com/u/7997532/Hands%20on%20Scala.js.pdf"
+  video_url: "https://www.youtube.com/embed/9SalPdAEI28"
+  description: >
+    This talk will explore the hands-on beginner experience of making things with Scala.js. In particular, it will cover a few topics:<br/>
+    <ul>
+    <li>How to make a standalone Scala.js single-page web app</li>
+    <li>How to make and publish a cross-platform (JS/JVM) Scala library</li>
+    <li>How to make a client-server Scala.js website with shared code</li>
+    </ul><br/>
+    Each topic will take 25 minutes, and will take you through the entire process from "clone this repo from Github" to "complete, usable project". By the end of this, anyone who's familiar with both Scala and web-dev should be ready to begin cranking out their next project in Scala.js, whatever that may be.<br/><br/>
+    Bring your computers with SBT and IDEs ready to follow along!
+
+- title: "Unruly Creatures: Strategies for dealing with Real Numbers"
+  speaker: "Erik Osheim"
+  slides_url: "http://plastic-idolatry.com/erik/pnwscala2014.pdf"
+  video_url: "https://www.youtube.com/embed/R7cYqrsGvG0"
+  description: >
+    If computers are supposed to be good at math, then why is it so hard to do math correctly with computers? We have trained programmers to reach for floating point types, and to deal with the fallout using some combination of profanity, resignation, and numerical analysis.</p><p>
+    We will explore alternatives, focusing on computable real numbers as implemented in Spire, as well as discussing alternatives such as Algebraic numbers and Continued fractions. The focus will be on practical use cases, as well as the benefits of laziness and functional programming when implementing and using these exotic types.
+
+- title: "What every (Scala) programmer should know about category theory"
+  speaker: "Gabriel Claramunt"
+  slides_url: "https://docs.google.com/presentation/d/1xLyJTTt47LOmQ7cwiEmTpFSJl0OVE6tDatOQPJ2R-34/pub"
+  video_url: "https://www.youtube.com/embed/W67LYX_1J_M"
+  description: >
+    Aren't you tired of just nodding along when your friends starts talking about morphisms? Do you feel left out when your coworkers discuss a coproduct endofunctor? From the dark corners of mathematics to a programming language near you, category theory offers a compact but powerful set of tools to build and reason about programs. What's a category? What's a functor? This talks aims to present the basic concepts and why they matter to everyday coding.</p><p>
+    Next time, you too can be the soul of the party and impress your friends with category theory!*</p><p>
+    *(results may vary)
+
+- title: "Building a Better Future: Advanced Error Handling for Concurrent Programming with Scalaz and Shapeless"
+  speaker: "Jean-Rémi Desjardins, Eddie Carlson"
+  slides_url: "https://docs.google.com/presentation/d/15ovgt-4GLOYy1j4VbVE6C-4QLrNEw2-F-yDejEEbJ6Y/edit#slide=id.p"
+  video_url: "https://www.youtube.com/embed/tU4pU5vaddU"
+  description: >
+    Here at Whitepages, we are redesigning a search system that must execute tasks concurrently, while providing smart flow-control and recovery in the presence of failures.</p><p>
+    We need a nuanced handling of errors for a variety of failure modes, which standard Futures alone do not provide. The system must also support timeouts at multiple levels in a way that allows recovery of useful information. Furthermore, the plan definition code must be clear, concise, and correct.</p><p>
+    In order to achieve the above goals in a functional and type-safe manner, we need a new, powerful abstraction. We decided to build a new future for ourselves! We would very much like to talk about our experience using and adapting Scalaz and Shapeless to implement functional, multi-faceted error handling of concurrent tasks.
+
+- title: "Composing Project Archetypes with SBT AutoPlugins"
+  speaker: "Mark Schaake"
+  slides_url: "http://www.slideshare.net/MarkSchaake/archetype-autoplugins-41615456"
+  video_url: "https://www.youtube.com/embed/bXBupZFJUPE"
+  description: >
+    SBT 0.13.5 introduced AutoPlugins as the future of SBT plugin development. AutoPlugins provide interesting features that simplify plugin development while enabling exciting new possibilities for plugin composition. At the Allen Institute for Artificial Intelligence, we are composing some core AutoPlugins into "Archetype" plugins for Library, CLI, WebService, and WebApplication projects. This strategy has proven to greatly simplify our SBT builds while enforcing consistency across projects (something we value very much at AI2!).

--- a/src/site/_includes/countdown.html
+++ b/src/site/_includes/countdown.html
@@ -1,0 +1,38 @@
+    <div class="counter">
+      <div class="container">
+        <div class="row">
+          <!-- ///  digits  /// -->
+          <div class="col-md-8">
+            <div class="row" id="countdown" data-date="{{ site.data.2016.event.event_start }}">
+              <div class="col-md-3 count-digits wow fadeInDown" data-wow-delay="1s">
+                <p id="days">20</p>
+                <span class="lead">Days</span>
+              </div>
+              <div class="col-md-3 count-digits wow fadeInDown" data-wow-delay="1.2s">
+                <p id="hours">16</p>
+                <span class="lead">Hours</span>
+              </div>
+              <div class="col-md-3 count-digits wow fadeInDown" data-wow-delay="1.4s">
+                <p id="minutes">10</p>
+                <span class="lead">Minutes</span>
+              </div>
+              <div class="col-md-3 count-digits wow fadeInDown" data-wow-delay="1.6s">
+                <p id="seconds">10</p>
+                <span class="lead">Seconds</span>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-12 text-center wow fadeInUp" data-wow-delay="1.8s">
+            <h1>PNWScala {{ site.data.2016.event.event_year }}</h1>
+            <p class="lead">
+              PORTLAND, OREGON <br>
+              {{ site.data.2016.event.event_month_day }}, {{ site.data.2016.event.event_year }}
+            </p>
+            <ul class="list-inline join-us">
+                <li><a href="https://twitter.com/pnwscala" class="btn btn-empty-inverse btn-lg"><i class="fa fa fa-twitter"></i></a></li>
+                <li><a href="http://www.youtube.com/playlist?list=PLZzBLqtaWWlie50nc_WoGWSw5ZMTpr8pY" class="btn btn-empty-inverse btn-lg"><i class="fa fa fa-youtube"></i></a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>

--- a/src/site/_includes/footer.html
+++ b/src/site/_includes/footer.html
@@ -1,0 +1,38 @@
+    <footer class="main-footer">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-12 social text-center">
+            <ul class="list-inline">
+              <li>
+                <a href="https://twitter.com/pnwscala"><i class="fa fa-twitter-square"></i></a>
+                <a href="http://www.youtube.com/playlist?list=PLZzBLqtaWWlie50nc_WoGWSw5ZMTpr8pY"><i class="fa fa-youtube"></i></a>
+                <a href="mailto:info@pnwscala.org"><i class="fa fa-envelope"></i></a>
+              </li>
+            </ul>
+          </div>
+          <div class="col-sm-12 text-center">
+            <span>All rights reserved</span>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <!-- ///  end footer  /// -->
+
+    <!-- ///  start script  /// -->
+    <!-- ///  libs  /// -->
+    <script src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/libs/modernizr-latest.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/libs/jquery-1.11.0.min.js"></script>
+    <script src="{{ site.assets_basedir }}/bootstrap-3.1.1/js/bootstrap.min.js"></script>
+    <!-- ///  plugins  /// -->
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/fitvids/jquery.fitvids.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/select/bootstrap-select.min.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/gmap3/gmap3.min.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/scrollTo/jquery.scrollTo.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/nav/jquery.nav.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/countdown/countdown.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/placeholder/jquery.placeholder.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/validator/jquery.form-validator.min.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/plugins/wow/wow.min.js"></script>
+    <script src="{{ site.assets_basedir }}/assets/js/main.js"></script>
+    <script src='https://ti.to/pnwscala/2014.js?version=3' type='text/javascript'></script>

--- a/src/site/_includes/head.html
+++ b/src/site/_includes/head.html
@@ -1,0 +1,23 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <!-- ///  page title  /// -->
+  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- /// font icons  /// -->
+  <link rel="stylesheet" type="text/css" href="{{ site.assets_basedir }}/assets/fonts/fontawesome/css/font-awesome.css">
+  <link rel="stylesheet" type="text/css" href="{{ site.assets_basedir }}/assets/fonts/linecons/css/linecons.css">
+  <!-- ///  google fonts  /// -->
+  <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic' rel='stylesheet' type='text/css'>
+  <!-- ///  animate.css  /// -->
+  <link rel="stylesheet" type="text/css" href="{{ site.assets_basedir }}/assets/css/plugins/animate/animate.css">
+  <!-- ///  bootstrap-select.css /// -->
+  <link rel="stylesheet" type="text/css" href="{{ site.assets_basedir }}/assets/css/plugins/select/bootstrap-select.css">
+  <!-- ///  bootstrap.css  /// -->
+  <link rel="stylesheet" type="text/css" href="{{ site.assets_basedir }}/bootstrap-3.1.1/css/bootstrap.css">
+  <!-- ///  main CSS file  /// -->
+  <link rel="stylesheet" type="text/css" href="{{ site.assets_basedir }}/assets/css/main.css">
+  <!-- /// tito CSS styling /// -->
+  <link rel="stylesheet" type="text/css" href='https://ti.to/pnwscala/2014.css?version=4' />
+</head>

--- a/src/site/_includes/header.html
+++ b/src/site/_includes/header.html
@@ -1,0 +1,27 @@
+  <header class="main-header">
+    <nav class="navbar navbar-custom navbar-fixed-top" role="navigation">
+      <div class="container">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+          <a class="navbar-brand" href="#"><i class="fa fa-signal success-color"></i> PNWScala <b>{{ site.data.2016.event.event_year }}</b></a>
+        </div>
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+          <ul class="nav navbar-nav navbar-right" id="archive-nav">
+            <li><a href="/2014/index.html">&nbsp;2014</a></li>
+            <li><a href="/2013/index.html">&nbsp;2013</a></li>
+          </ul>
+          <ul class="nav navbar-nav navbar-right" id="nav">
+            <li class="active"><a href="#home">Home</a></li>
+            <li><a href="#schedule">Schedule</a></li>
+            <li><a href="#speakers">Speakers</a></li>
+            <li><a href="#talks">Talks</a></li>
+            <li><a href="#sponsors">Sponsors</a></l>
+            <li><a href="#registration">Registration</a></li>
+            <li><a href="#ourLocation">Contact</a></li>
+          </ul>
+        </div><!-- /.navbar-collapse -->
+
+      </div><!-- /.container-fluid -->
+    </nav>
+  </header>

--- a/src/site/_includes/other.html
+++ b/src/site/_includes/other.html
@@ -1,0 +1,141 @@
+    <!-- /// begin registration /// -->
+    <div class="registration" id="registration">
+      <div class="container">
+        <div class="row">
+          <div class="section-heading">
+            <h1>Registration</h1>
+
+            <div id='tito-register-form'></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- /// end registration /// -->
+
+
+    <!-- ///  begin faq  /// -->
+    <!--
+    <div class="faq" id="cfp">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-4"></div>
+          <div class="col-md-8">
+
+            <h1>Call for Proposals</h1>
+            <p class="lead">The Pacific Northwest Scala Conference will be taking place this year in Portland, Oregon on {{ site.data.2016.event.event_month_day_long }}. We look forward to engaging with Scala users and those interested in learning more about Scala, from the Pacific Northwest and beyond. We will be hosting a two-day event with two days of single-track talks. If you have a topic you’re passionate about – perhaps an area of interest in which you've become your company's or user-group's resident expert – or a new approach you'd like to share, we encourage you to submit a proposal for a talk.</p>
+
+            <p class="cfp">We strongly encourage anyone from typically under-represented groups to submit proposals. We want to promote diversity in this community and we guarantee that all submissions will be given equal consideration.</p>
+
+            <p class="cfp">Also, we’ll be including the option to submit talks as either a typical presentation length (40 minutes, including time for Q&amp;A) or as longer, workshop-style presentations that can be more hands-on or go more in-depth into areas of deeper interest. If your talk might fit into either category, please let us know on the submission form.</p>
+
+            <p class="cfp">Areas of interest that talks might cover include (but are certainly not limited to):
+            <ul class="cfp">
+              <li>Case studies & experience reports</li>
+              <li>Interesting patterns & designs</li>
+              <li>Reliability & fault-tolerance</li>
+              <li>Concurrency & distributed systems</li>
+              <li>Data management & large-scale data</li>
+              <li>Tools & techniques</li>
+              <li>Domain-Specific Languages</li>
+              <li>Functional programming</li>
+              <li>Migrating to Scala from other languages</li>
+              <li>Beginner focused topics</li>
+            </ul>
+            </p>
+
+            <p class="cfp">If you would like to give a talk at PNWScala {{ site.data.2016.event.event_year }}, please submit your information using this form. Submissions are due by {{ site.data.2016.event.cfp_submit_deadline }} and we will be selecting talks by {{ site.data.2016.event.cfp_selection_deadline }} at the latest. Please note that if your talk is accepted, you will be given free admittance (normally ${{ site.data.2016.event.event_price }}) to the conference. You may want to go ahead and register before we make selections (registration will be online very soon), in order to guarantee a spot. We’ll refund your fees if your talk is selected.</p>
+
+            <p class="cfp"><a href="https://docs.google.com/forms/d/1a6RcHXRNz8rmFRST4s_du8tZOMD5IxTh4ywQG0BlL_c/viewform?usp=send_form">Submit your proposal here.</a></p>
+
+          </div>
+        </div>
+      </div>
+    </div>
+-->
+    <!-- ///  end faq  /// -->
+
+
+
+
+
+    <!-- ///  begin map, subscribe, contacts  /// -->
+    <!-- ///  set your venue address in data-location attribute  /// -->
+    <div class="map" id="ourLocation" data-location="101 North Weidler Street,
+Portland, OR">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-lg-12 map-container" id="map">
+          </div>
+        </div>
+      </div>
+      <div class="location wow flipInY">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-12">
+              <div class="popover bottom">
+                <div class="arrow"></div>
+                <h2 class="popover-title">Location</h2>
+                <div class="popover-content">
+                  <div class="row">
+                    <div class="col-sm-6">
+                      <div class="street-view" id="streetView"></div>
+                    </div>
+                    <div class="col-sm-6">
+                      <ul class="list-unstyled">
+                        <li><i class="fa fa-map-marker info-color"></i>101 North Weidler Street,
+                          Portland, OR</li>
+                        <li><i class="fa fa-envelope info-color"></i>info@pnwscala.org</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- ///  end map, subscribe, contacts  /// -->
+
+    <!-- /// begin code of conduct /// -->
+    <div class="wow fadeInUp" id="conduct">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Code of Conduct</h2>
+
+          <h3>The Short Version</h3>
+
+          <p>PNWScala is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion (or lack thereof). We do not tolerate harassment of conference participants in any form. </p>
+
+          <p>All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language, innuendo, and imagery is not appropriate for any conference venue, including talks.</p>
+
+          <p>Conference participants violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.</p>
+
+
+          <h3>The Long Version</h3>
+
+          <p>Harassment includes offensive verbal comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion; sexual images in public spaces; deliberate intimidation; stalking, following, harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention. </p>
+
+          <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+
+          <p>Sponsors and other exhibitors are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.</p>
+
+          <p>If a participant engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
+
+          <p>We expect participants to follow these rules at all conference venues and conference-related social events</p>
+
+          <h3>Contact Information</h3>
+
+          <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the conference staff immediately.</p>
+
+          <p>For any questions or concerns, please email the organizers at <a href="mailto:info@pnwscala.org">info@pnwscala.org</a>.  Phone number contacts for organizers and law enforcement will be available on this page during the event.</p>
+
+          <p>Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
+
+         <h3>License</h3>
+          <p>This Code of Conduct was derived from the example policy from the <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">Geek Feminism wiki, created by the Ada Initiative and other volunteers</a> and the <span href="http://purl.org/dc/dcmitype/Text" rel="dct:type">Conference Code of Conduct</span> by <a href="https://us.pycon.org/2013/about/code-of-conduct/" rel="cc:attributionURL">https://us.pycon.org/2013/about/code-of-conduct/</a> and  is licensed under a <a href="http://creativecommons.org/licenses/by/3.0/" rel="license">Creative Commons Attribution 3.0 Unported License</a>.</p>
+<p><a href="http://creativecommons.org/licenses/by/3.0/" rel="license"><img src="http://i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License" style="border-width: 0;"/></a></p>
+        </div>
+      </div>
+    </div>
+    <!-- /// end code of conduct /// -->

--- a/src/site/_includes/promo.html
+++ b/src/site/_includes/promo.html
@@ -1,0 +1,20 @@
+    <div class="promo" id="home" style="background-image:url(../assets/img/portland_at_night.jpg);">
+      <!-- ///  semitransparent layer  /// -->
+      <div class="color-correction"></div>
+      <!-- ///  begin entry  /// -->
+      <div class="container">
+        <div class="row">
+          <!-- ///  begin text section  /// -->
+          <div class="col-md-6 wow fadeInDown" data-wow-duration="2s">
+            <div class="promo-text">
+              <img id="mainlogo" src="../assets/img/pnwscala_logo2.png" style="float:left; padding-right: 1em;"/>
+              <h1><i class="fa fa-signal success-color"></i> PNWScala <b>{{ site.data.2016.event.event_year }}</b></h1>
+              <hr>
+              <p class="lead">Join other Scala fans and practitioners in Portland, Oregon for 2 days of enlightening talks.</p>
+              <p>The Pacific Northwest Scala Conference is a regional event focusing on a wide range of Scala-related topics, and will bring together Scala enthusiasts from the Pacfic Northwest and far beyond.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- ///  end entry  /// -->
+    </div>

--- a/src/site/_includes/schedule.html
+++ b/src/site/_includes/schedule.html
@@ -1,0 +1,52 @@
+<div class="schedule" id="schedule">
+  <div class="container">
+    <div class="section-heading">
+      <h1>Schedule</h1>
+    </div>
+    <div class="row">
+      <div class="col-md-12 wow fadeInDown">
+        <!-- Nav tabs -->
+        <ul class="nav nav-tabs nav-justified">
+        {% for d in site.data.2016.schedule %}
+          <li {% if forloop.index == 1 %}class="active"{% endif %}><a href="#{{ d.day }}" data-toggle="tab">{{ d.day }}, {{ d.date }}</a></li>
+        {% endfor %}
+        </ul>
+        <!-- Tab panes -->
+        <div class="tab-content">
+        {% for date in site.data.2016.schedule %}
+          <div class="tab-pane {% if forloop.index == 1 %}active{% endif %}" id="{{ date.day }}">
+            <div class="panel-group" id="accordion">
+              {% for event in date.events %}
+              <div class="panel panel-default">
+                <div class="panel-heading">
+                  <h4 class="panel-title">
+                    {% if event.speaker %}
+                      <a data-toggle="collapse" data-parent="#accordion" href="#collapse-{{ date.day }}-{{ forloop.index }}">
+                        {{ event.time }} - {{ site.data.2016.talks | where: "speaker", event.speaker | map: "title" }}
+                      </a>
+                      -
+                    <a href="#{{ event.speaker | slugify }}">{{ event.speaker }}</a>
+                    {% else %}
+                      {{ event.time }} - {{ event.title }}
+                    {% endif %}
+                  </h4>
+                </div>
+                {% if event.speaker %}
+                <div id="collapse-{{ date.day }}-{{ forloop.index }}" class="panel-collapse collapse">
+                  <div class="panel-body">
+                    <p>
+                      {{ site.data.2016.talks | where: "speaker", event.speaker | map: "description" }}
+                    </p>
+                  </div>
+                </div>
+                {% endif %}
+              </div>
+              {% endfor %}
+            </div>
+          </div>
+        {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/site/_includes/speakers.html
+++ b/src/site/_includes/speakers.html
@@ -1,0 +1,23 @@
+<div class="speakers" id="speakers">
+  <div class="container">
+    <div class="row text-center">
+      <div class="section-heading">
+        <h1>Speakers</h1>
+      </div>
+      {% for speaker in site.data.2016.speakers %}
+      {% assign loopindex = forloop.index | modulo: 3 %}
+        {% if loopindex == 1 %}
+        <div class="row text-center">
+        {% endif %}
+        <div class="col-md-4">
+          <h3 id="{{ speaker.name | slugify }}">{{ speaker.name }}</h3>
+          <hr>
+          <p>{{ speaker.bio }}</p>
+        </div>
+        {% if loopindex == 0 or forloop.last %}
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/src/site/_includes/sponsors.html
+++ b/src/site/_includes/sponsors.html
@@ -1,0 +1,20 @@
+<div class="sponsors wow fadeInUp" id="sponsors">
+  <div class="container">
+    <div class="section-heading">
+      <h1>Sponsors</h1>
+      <p class="lead">PNWScala would not be possible without the help of our generous sponsors.</p>
+    </div>
+    <div class="row text-center">
+      {% for tier in site.data.2016.sponsors %}
+      <div class="col-lg-12">
+        <h2>{{ tier.title }}</h2>
+          <ul class="list-inline">
+          {% for company in tier.companies %}
+            <li><a href="{{ company.url }}"><img src="{{ company.logo_url }}" alt="{{ company.name }}" style="{{ company.logo_styling }}"></a></li>
+          {% endfor %}
+          </ul>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/src/site/_includes/talks.html
+++ b/src/site/_includes/talks.html
@@ -1,0 +1,34 @@
+<div class="talks" id="talks">
+  <div class="container">
+    <div class="row">
+      <div class="section-heading text-center">
+        <h1>Talks</h1>
+      </div>
+
+      {% for talk in site.data.2016.talks %}
+      {% assign loopindex = forloop.index | modulo: 2 %}
+        {% if loopindex == 1 %}
+        <div class="row">
+        {% endif %}
+        <div class="col-md-6">
+          <h3>{{ talk.title }}</h3>
+          <h4><a href="#{{ talk.speaker | slugify }}">{{ talk.speaker }}</a></h4>
+          {% if talk.video_url %}
+          <iframe width="560" height="315" src="{{ talk.video_url }}" frameborder="0" allowfullscreen></iframe>
+          <br/>
+          {% endif %}
+          <p>{{ talk.description }}</p>
+          <hr/>
+          {% if talk.slides_link %}
+          <ul>
+            <li><a href="{{ talk.slides_url }}">Slides</a></li>
+          </ul>
+          {% endif %}
+        </div>
+        {% if loopindex == 0 %}
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/src/site/_layouts/default.html
+++ b/src/site/_layouts/default.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+
+  {% include head.html %}
+
+  <body class="remove-scroll">
+
+    {% include header.html %}
+
+    <div class="page-content">
+      <div class="wrapper">
+        {{ content }}
+      </div>
+    </div>
+
+    {% include footer.html %}
+
+  </body>
+
+</html>


### PR DESCRIPTION
- schedules, speakers, talks, sponsors, and event dates managed in data files
- all dates and data are just a placeholder for testing
- assets are borrowing from 2014, but should be shuffled around eventually